### PR TITLE
Bioc coding practice notes

### DIFF
--- a/R/class_definitions.R
+++ b/R/class_definitions.R
@@ -23,6 +23,7 @@ NULL
 #' @name domino-class
 #' @rdname domino-class
 #' @exportClass domino
+#' @return an instance of class `domino `
 #'
 domino <- methods::setClass(
   Class = "domino",
@@ -58,6 +59,7 @@ domino <- methods::setClass(
 #' @name linkage_summary-class
 #' @rdname linkage_summary-class
 #' @exportClass linkage_summary
+#' @return an instance of class `linkage_summary`
 #'
 linkage_summary <- setClass(
   Class = "linkage_summary",

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -87,7 +87,7 @@ create_rl_map_cellphonedb <- function(
       component_a <- as.character(complex_a[, c("uniprot_1", "uniprot_2", "uniprot_3", "uniprot_4")])
       component_a <- component_a[component_a != ""]
       a_features[["uniprot_A"]] <- paste(component_a, collapse = ",")
-      gene_a <- sapply(component_a, function(x) {
+      gene_a <- vapply(component_a, FUN.VALUE = character(1), FUN = function(x) {
         g <- unique(genes[genes[["uniprot"]] == x, c("gene_name")])
         if (!is.null(gene_conv) & !identical(gene_conv[1], gene_conv[2])) {
           # if the original gene trying to be converted is not in the gene dictionary the
@@ -143,7 +143,7 @@ create_rl_map_cellphonedb <- function(
       component_b <- as.character(complex_b[, c("uniprot_1", "uniprot_2", "uniprot_3", "uniprot_4")])
       component_b <- component_b[component_b != ""]
       b_features[["uniprot_B"]] <- paste(component_b, collapse = ",")
-      gene_b <- sapply(component_b, function(x) {
+      gene_b <- vapply(component_b, FUN.VALUE = character(1), FUN = function(x) {
         g <- unique(genes[genes[["uniprot"]] == x, c("gene_name")])
         if (!is.null(gene_conv) & !identical(gene_conv[1], gene_conv[2])) {
           # if the original gene trying to be converted is not in the gene dictionary the
@@ -530,7 +530,7 @@ create_domino <- function(
   if (tf_selection_method == "clusters") {
     cl_rec_percent <- NULL
     for (rec in ser_receptors) {
-      rec_percent <- sapply(X = levels(dom@clusters), FUN = function(x) {
+      rec_percent <- vapply(X = levels(dom@clusters), FUN.VALUE = numeric(1), FUN = function(x) {
         # percentage of cells in cluster with non-zero expression of receptor gene
         sum(dom@counts[rec, dom@clusters == x] > 0) / length(dom@counts[rec, dom@clusters ==
           x])

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -105,14 +105,12 @@ create_rl_map_cellphonedb <- function(
           res <- g
         } else {
           res <- g[1]
-          if(verbose) {
-            g_col <- paste(g, collapse = ", ")
-            message(
-              component_a, " has multiple encoding gene mapped in genes table.\n",
-              g_col, "\n",
-              "The first mapping gene is used: ", res
-            )
-          }
+          g_col <- paste(g, collapse = ", ")
+          message(
+            component_a, " has multiple encoding gene mapped in genes table.\n",
+            g_col, "\n",
+            "The first mapping gene is used: ", res
+          )
         }
         return(res)
       })
@@ -175,14 +173,12 @@ create_rl_map_cellphonedb <- function(
           res <- g
         } else {
           res <- g[1]
-          if(verbose) {
-            g_col <- paste(g, collapse = ", ")
-            message(
-              component_a, " has multiple encoding gene mapped in genes table.\n",
-              g_col, "\n",
-              "The first mapping gene is used: ", res
-            )
-          }
+          g_col <- paste(g, collapse = ", ")
+          message(
+            component_a, " has multiple encoding gene mapped in genes table.\n",
+            g_col, "\n",
+            "The first mapping gene is used: ", res
+          )
         }
         return(res)
       })

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -325,7 +325,7 @@ create_domino <- function(
   if ("database_name" %in% colnames(rl_map)) {
     dom@db_info <- rl_map
     if (verbose) {
-      message(paste0("Database provided from source: ", unique(rl_map[["database_name"]])))
+      message("Database provided from source: ", unique(rl_map[["database_name"]]))
     }
   } else {
     dom@db_info <- rl_map
@@ -415,7 +415,7 @@ create_domino <- function(
     for (clust in levels(dom@clusters)) {
       if (verbose) {
         cur <- which(levels(dom@clusters) == clust)
-        message(paste0(cur, " of ", clust_n))
+        message(cur, " of ", clust_n)
       }
       cells <- which(dom@clusters == clust)
       for (feat in rownames(dom@features)) {
@@ -463,7 +463,7 @@ create_domino <- function(
     # correlation equal to 0.
     if (verbose) {
       cur <- which(rownames(dom@features) == module)
-      message(paste0(cur, " of ", n_tf))
+      message(cur, " of ", n_tf)
     }
     if (!is.null(dom@linkages$tf_targets)) {
       tf <- gsub(pattern = "\\.\\.\\.", replacement = "", module) # correction for AUC values from pySCENIC that append an elipses to TF names due to (+) characters in the orignial python output

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -101,8 +101,20 @@ create_rl_map_cellphonedb <- function(
           }
         }
         # if multiple genes are annotated for the uniprot ID, use only the first unique instance
-        g <- g[1]
-        return(g)
+        if(length(g) == 1){
+          res <- g
+        } else {
+          res <- g[1]
+          if(verbose) {
+            g_col <- paste(g, collapse = ", ")
+            message(
+              component_a, " has multiple encoding gene mapped in genes table.\n",
+              g_col, "\n",
+              "The first mapping gene is used: ", res
+            )
+          }
+        }
+        return(res)
       })
       a_features[["gene_A"]] <- paste(gene_a, collapse = ",")
       # annotation as a receptor or ligand is based on the annotation of the complex
@@ -159,8 +171,20 @@ create_rl_map_cellphonedb <- function(
           }
         }
         # if multiple genes are annotated for the uniprot ID, use only the first unique instance
-        g <- g[1]
-        return(g)
+        if(length(g) == 1){
+          res <- g
+        } else {
+          res <- g[1]
+          if(verbose) {
+            g_col <- paste(g, collapse = ", ")
+            message(
+              component_a, " has multiple encoding gene mapped in genes table.\n",
+              g_col, "\n",
+              "The first mapping gene is used: ", res
+            )
+          }
+        }
+        return(res)
       })
       b_features[["gene_B"]] <- paste(gene_b, collapse = ",")
       # annotation as a receptor or ligand is based on the annotation of the complex

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -75,7 +75,7 @@ create_rl_map_cellphonedb <- function(
   }
   # Step through the interactions and build rl connections.
   rl_map <- NULL
-  for (i in 1:nrow(interactions)) {
+  for (i in seq(nrow(interactions))) {
     inter <- interactions[i, ]
     partner_a <- inter[["partner_a"]]
     partner_b <- inter[["partner_b"]]
@@ -338,7 +338,7 @@ create_domino <- function(
   }
   # Get genes for receptors
   rl_reading <- NULL
-  for (i in 1:nrow(rl_map)) {
+  for (i in seq(nrow(rl_map))) {
     rl <- list()
     inter <- rl_map[i, ]
     p <- ifelse(inter[["type_A"]] == "R", "A", "B")
@@ -366,7 +366,7 @@ create_domino <- function(
   dom@linkages$complexes <- NULL
   if (use_complexes) {
     complex_list <- list()
-    for (i in 1:nrow(rl_reading)) {
+    for (i in seq(nrow(rl_reading))) {
       inter <- rl_reading[i, ]
       if (grepl("\\,", inter[["L.gene"]])) {
         complex_list[[inter[["L.name"]]]] <- unlist(strsplit(inter[["L.gene"]], split = "\\,"))
@@ -502,7 +502,7 @@ create_domino <- function(
   dom@misc$rec_cor <- rho
   # assess correlation among genes in the same receptor complex
   cor_list <- list()
-  for (i in 1:length(names(dom@linkages$rec_lig))) {
+  for (i in seq_along(names(dom@linkages$rec_lig))) {
     r <- names(dom@linkages$rec_lig)[i]
     if (r %in% names(dom@linkages$complexes)) {
       r_genes <- dom@linkages$complexes[[r]]
@@ -623,7 +623,7 @@ add_rl_column <- function(map, map_ref, conv, new_name) {
     not_in_ref_map <- c()
   }
   new_map <- c()
-  for (r_id in 1:nrow(map)) {
+  for (r_id in seq(nrow(map))) {
     row <- map[r_id, ]
     conv_ids <- which(conv[, 1] == row[[map_ref]])
     for (id in conv_ids) {

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -510,7 +510,6 @@ create_domino <- function(
       r_genes <- r
     }
     if (sum(rownames(rho) %in% r_genes) != length(r_genes)) {
-      message(paste0(r, " has component genes that did not pass testing parameters"))
       cor_list[[r]] <- rep(0, ncol(rho))
       next
     }

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -100,6 +100,8 @@ create_rl_map_cellphonedb <- function(
             g <- paste(unique(conv_dict[conv_dict[, 1] %in% g, 2]), collapse = ";")
           }
         }
+        # if multiple genes are annotated for the uniprot ID, use only the first unique instance
+        g <- g[1]
         return(g)
       })
       a_features[["gene_A"]] <- paste(gene_a, collapse = ",")
@@ -156,6 +158,8 @@ create_rl_map_cellphonedb <- function(
             g <- paste(unique(conv_dict[conv_dict[, 1] %in% g, 2]), collapse = ";")
           }
         }
+        # if multiple genes are annotated for the uniprot ID, use only the first unique instance
+        g <- g[1]
         return(g)
       })
       b_features[["gene_B"]] <- paste(gene_b, collapse = ",")

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -75,7 +75,7 @@ create_rl_map_cellphonedb <- function(
   }
   # Step through the interactions and build rl connections.
   rl_map <- NULL
-  for (i in seq(nrow(interactions))) {
+  for (i in seq_len(nrow(interactions))) {
     inter <- interactions[i, ]
     partner_a <- inter[["partner_a"]]
     partner_b <- inter[["partner_b"]]
@@ -362,7 +362,7 @@ create_domino <- function(
   }
   # Get genes for receptors
   rl_reading <- NULL
-  for (i in seq(nrow(rl_map))) {
+  for (i in seq_len(nrow(rl_map))) {
     rl <- list()
     inter <- rl_map[i, ]
     p <- ifelse(inter[["type_A"]] == "R", "A", "B")
@@ -391,7 +391,7 @@ create_domino <- function(
   dom@linkages$complexes <- NULL
   if (use_complexes) {
     complex_list <- list()
-    for (i in seq(nrow(rl_reading))) {
+    for (i in seq_len(nrow(rl_reading))) {
       inter <- rl_reading[i, ]
       if (grepl("\\,", inter[["L.gene"]])) {
         complex_list[[inter[["L.name"]]]] <- unlist(strsplit(inter[["L.gene"]], split = "\\,"))
@@ -648,7 +648,7 @@ add_rl_column <- function(map, map_ref, conv, new_name) {
     not_in_ref_map <- c()
   }
   new_map <- c()
-  for (r_id in seq(nrow(map))) {
+  for (r_id in seq_len(nrow(map))) {
     row <- map[r_id, ]
     conv_ids <- which(conv[, 1] == row[[map_ref]])
     for (id in conv_ids) {

--- a/R/import_fxns.R
+++ b/R/import_fxns.R
@@ -390,6 +390,7 @@ create_domino <- function(
     rl <- as.data.frame(rl)
     rl_reading <- rbind(rl_reading, rl)
   }
+  if(nrow(rl_reading) == 0) stop("No genes annotated as receptors included in rl_map")
   # save a list of complexes and their components
   dom@linkages$complexes <- NULL
   if (use_complexes) {

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -756,7 +756,7 @@ cor_scatter <- function(dom, tf, rec, remove_rec_dropout = TRUE, ...) {
 #' circos_ligand_receptor(dominoSignal:::pbmc_dom_built_tiny, receptor = "CXCR3")
 #' #specify colors
 #' cols = c("red", "orange", "green", "blue", "pink", "purple", "slategrey", "firebrick", "hotpink")
-#' names(cols) = levels(dominoSignal:::pbmc_dom_built_tiny@clusters)
+#' names(cols) = levels(dom_clusters(dominoSignal:::pbmc_dom_built_tiny))
 #' circos_ligand_receptor(dominoSignal:::pbmc_dom_built_tiny, receptor = "CXCR3", cell_colors = cols)
 #' 
 circos_ligand_receptor <- function(

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -1003,5 +1003,5 @@ do_norm <- function(mat, dir) {
 #' 
 ggplot_col_gen <- function(n) {
   hues <- seq(15, 375, length = n + 1)
-  return(grDevices::hcl(h = hues, l = 65, c = 100)[seq(n)])
+  return(grDevices::hcl(h = hues, l = 65, c = 100)[seq_len(n)])
 }

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -289,7 +289,7 @@ signaling_network <- function(
   }
   # Get vert angle for labeling circos plot
   if (layout == "circle") {
-    v_angles <- 1:length(igraph::V(graph))
+    v_angles <- seq(length(igraph::V(graph)))
     v_angles <- -2 * pi * (v_angles - 1) / length(v_angles)
     igraph::V(graph)$label.degree <- v_angles
   }
@@ -465,9 +465,9 @@ gene_network <- function(dom, clust = NULL, OutgoingSignalingClust = NULL,
     l[all_ligs, 1] <- -0.75
     l[all_recs, 1] <- 0
     l[all_tfs, 1] <- 0.75
-    l[all_ligs, 2] <- (1:length(all_ligs) / mean(1:length(all_ligs)) - 1) * 2
-    l[all_recs, 2] <- (1:length(all_recs) / mean(1:length(all_recs)) - 1) * 2
-    l[all_tfs, 2] <- (1:length(all_tfs) / mean(1:length(all_tfs)) - 1) * 2
+    l[all_ligs, 2] <- (seq_along(all_ligs) / mean(seq_along(all_ligs)) - 1) * 2
+    l[all_recs, 2] <- (seq_along(all_recs) / mean(seq_along(all_recs)) - 1) * 2
+    l[all_tfs, 2] <- (seq_along(all_tfs) / mean(seq_along(all_tfs)) - 1) * 2
     rownames(l) <- c()
   } else if (layout == "random") {
     l <- igraph::layout_randomly(graph)
@@ -814,7 +814,7 @@ circos_ligand_receptor <- function(
     names(cell_colors) <- cell_idents
   }
   grid_col <- c("#FFFFFF") # hide the arc corresponding to the receptor by coloring white
-  for (i in 1:length(ligands)) {
+  for (i in seq_along(ligands)) {
     grid_col <- c(grid_col, rep(lig_colors[i], length(cell_idents)))
   }
   names(grid_col) <- c(receptor, signaling_df$origin)
@@ -955,7 +955,7 @@ plot_differential_linkages <- function(
     group_palette <- ggplot_col_gen(length(g_names))
     names(group_palette) <- g_names
   }
-  for (i in 1:length(g_names)) {
+  for (i in seq_along(g_names)) {
     g <- g_names[i]
     g_count <- paste0(g, "_count")
     g_n <- paste0(g, "_n")
@@ -1003,5 +1003,5 @@ do_norm <- function(mat, dir) {
 #' 
 ggplot_col_gen <- function(n) {
   hues <- seq(15, 375, length = n + 1)
-  return(grDevices::hcl(h = hues, l = 65, c = 100)[1:n])
+  return(grDevices::hcl(h = hues, l = 65, c = 100)[seq(n)])
 }

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -365,7 +365,7 @@ gene_network <- function(dom, clust = NULL, OutgoingSignalingClust = NULL,
       # Check if signaling exists for target cluster
       mat <- dom@cl_signaling_matrices[[cl]]
       if (dim(mat)[1] == 0) {
-        message(paste("No signaling found for", cl, "under build parameters."))
+        message("No signaling found for ", cl, " under build parameters.")
         (next)()
       }
       all_sums <- c(all_sums, rowSums(mat))
@@ -553,7 +553,7 @@ feat_heatmap <- function(
     na <- which(is.na(mid))
     na_feats <- paste(feats[na], collapse = " ")
     if (length(na) != 0) {
-      message(paste("Unable to find", na_feats))
+      message("Unable to find ", na_feats)
       feats <- feats[-na]
     }
   } else if (feats == "all") {
@@ -659,7 +659,7 @@ cor_heatmap <- function(
     na <- which(is.na(mid))
     na_feats <- paste(feats[na], collapse = " ")
     if (length(na) != 0) {
-      message(paste("Unable to find", na_feats))
+      message("Unable to find ", na_feats)
       feats <- feats[-na]
     }
   } else if (identical(feats, "all")) {
@@ -783,7 +783,7 @@ circos_ligand_receptor <- function(
       signaling_df <- rbind(signaling_df, df)
     }
   } else {
-    stop(paste0("No clusters have active ", receptor, " signaling"))
+    stop("No clusters have active ", receptor, " signaling")
   }
   signaling_df$mean.expression[is.na(signaling_df$mean.expression)] <- 0
   # create a scaled mean expression plot for coord widths greater than 1 by dividing by the max
@@ -791,7 +791,7 @@ circos_ligand_receptor <- function(
   signaling_df$scaled.mean.expression <- signaling_df$mean.expression / max(signaling_df$mean.expression)
   # exit function if no ligands are expressed above ligand expression threshold
   if (sum(signaling_df[["mean.expression"]] > ligand_expression_threshold) == 0) {
-    stop(paste0("No ligands of ", receptor, " exceed ligand expression threshold."))
+    stop("No ligands of ", receptor, " exceed ligand expression threshold.")
   }
   # initialize chord diagram with even ligand arcs
   arc_df <- signaling_df[, c("origin", "destination")]
@@ -900,7 +900,7 @@ plot_differential_linkages <- function(
     differential_linkages, test_statistic, stat_range = c(0, 1),
     stat_ranking = c("ascending", "descending"), group_palette = NULL) {
   if (!test_statistic %in% colnames(differential_linkages)) {
-    stop(paste0("test statistic '", test_statistic, "' not present in colnames(differential_linkages)"))
+    stop("test statistic '", test_statistic, "' not present in colnames(differential_linkages)")
   }
   if (identical(stat_ranking, c("ascending", "descending"))) {
     warning("stat_ranking order not specified. Defaulting to ascending order")
@@ -913,7 +913,7 @@ plot_differential_linkages <- function(
   df <- differential_linkages[differential_linkages[[test_statistic]] >= stat_range[1] & differential_linkages[[test_statistic]] <=
     stat_range[2], ]
   if (nrow(df) == 0) {
-    stop(paste0("No features with '", test_statistic, "' within stat_range"))
+    stop("No features with '", test_statistic, "' within stat_range")
   }
   # order df by plot statistic
   if (stat_ranking == "ascending") {

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -769,7 +769,7 @@ circos_ligand_receptor <- function(
     cell_idents <- sort(unique(dom@clusters))
   }
   # obtain expression values from cl_signaling matrices
-  active_chk <- sapply(dom@linkages$clust_rec, function(x) {
+  active_chk <- vapply(dom@linkages$clust_rec, FUN.VALUE = logical(1), FUN = function(x) {
     receptor %in% x
   })
   if (sum(active_chk)) {

--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -46,12 +46,12 @@ build_domino <- function(
           fcs <- c(fcs, fc)
         }
         names(fcs) <- zeros
-        sorted <- sort(fcs, decreasing = TRUE)[1:max_tf_per_clust]
+        sorted <- sort(fcs, decreasing = TRUE)[seq(max_tf_per_clust)]
       } else {
         sorted <- ordered[which(ordered < min_tf_pval)]
       }
       if (length(sorted) > max_tf_per_clust) {
-        sorted <- sorted[1:max_tf_per_clust]
+        sorted <- sorted[seq(max_tf_per_clust)]
       }
       clust_tf[[clust]] <- names(sorted)
     }
@@ -62,7 +62,7 @@ build_domino <- function(
       ordered <- sort(dom@cor[, tf], decreasing = TRUE)
       filtered <- ordered[which(ordered > rec_tf_cor_threshold)]
       if (length(filtered) > max_rec_per_tf) {
-        top_receptors <- names(filtered)[1:max_rec_per_tf]
+        top_receptors <- names(filtered)[seq(max_rec_per_tf)]
       } else {
         top_receptors <- names(filtered)
       }
@@ -192,7 +192,7 @@ build_domino <- function(
       ordered <- sort(dom@cor[, tf], decreasing = TRUE)
       filtered <- ordered[which(ordered > rec_tf_cor_threshold)]
       if (length(filtered) > max_rec_per_tf) {
-        top_receptors <- names(filtered)[1:max_rec_per_tf]
+        top_receptors <- names(filtered)[seq(max_rec_per_tf)]
       } else {
         top_receptors <- names(filtered)
       }

--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -46,12 +46,12 @@ build_domino <- function(
           fcs <- c(fcs, fc)
         }
         names(fcs) <- zeros
-        sorted <- sort(fcs, decreasing = TRUE)[seq(max_tf_per_clust)]
+        sorted <- sort(fcs, decreasing = TRUE)[seq_len(max_tf_per_clust)]
       } else {
         sorted <- ordered[which(ordered < min_tf_pval)]
       }
       if (length(sorted) > max_tf_per_clust) {
-        sorted <- sorted[seq(max_tf_per_clust)]
+        sorted <- sorted[seq_len(max_tf_per_clust)]
       }
       clust_tf[[clust]] <- names(sorted)
     }
@@ -62,7 +62,7 @@ build_domino <- function(
       ordered <- sort(dom@cor[, tf], decreasing = TRUE)
       filtered <- ordered[which(ordered > rec_tf_cor_threshold)]
       if (length(filtered) > max_rec_per_tf) {
-        top_receptors <- names(filtered)[seq(max_rec_per_tf)]
+        top_receptors <- names(filtered)[seq_len(max_rec_per_tf)]
       } else {
         top_receptors <- names(filtered)
       }
@@ -192,7 +192,7 @@ build_domino <- function(
       ordered <- sort(dom@cor[, tf], decreasing = TRUE)
       filtered <- ordered[which(ordered > rec_tf_cor_threshold)]
       if (length(filtered) > max_rec_per_tf) {
-        top_receptors <- names(filtered)[seq(max_rec_per_tf)]
+        top_receptors <- names(filtered)[seq_len(max_rec_per_tf)]
       } else {
         top_receptors <- names(filtered)
       }

--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -115,7 +115,7 @@ build_domino <- function(
     for (clust in levels(dom@clusters)) {
       inc_ligs <- clust_ligs[[clust]]
       rl_map <- dom@misc[["rl_map"]]
-      inc_ligs <- sapply(inc_ligs, function(l) {
+      inc_ligs <- vapply(inc_ligs, FUN.VALUE = character(1), FUN = function(l) {
         int <- rl_map[rl_map$L.name == l, ][1, ]
         if ((int$L.name != int$L.gene) & !grepl("\\,", int$L.gene)) {
           int$L.gene

--- a/R/utils.R
+++ b/R/utils.R
@@ -270,7 +270,9 @@ dom_network_items <- function(dom, clusters = NULL, return = NULL) {
 #' @param need_colnames Logical for whether colnames are required
 #' @param need_rownames Logical for whether rownames are required
 #' @param need_names Logical for whether names are required
+#' @return logical
 #' @keywords internal
+#' 
 check_arg <- function(arg, allow_class = NULL, allow_len = NULL,
                       allow_range = NULL, allow_values = NULL,
                       need_vars = c(NULL), need_colnames = FALSE,

--- a/R/utils.R
+++ b/R/utils.R
@@ -238,7 +238,9 @@ dom_network_items <- function(dom, clusters = NULL, return = NULL) {
     for (cl in clusters) {
         all_recs <- c(all_recs, unlist(dom@linkages$clust_tf_rec[[cl]]))
         tfs <- names(dom@linkages$clust_tf_rec[[cl]])
-        tf_wo_rec <- which(sapply(dom@linkages$clust_tf_rec[[cl]], length) == 0)
+        tf_wo_rec <- which(
+          vapply(dom@linkages$clust_tf_rec[[cl]], FUN.VALUE = numeric(1), FUN = length) == 0
+        )
         if (length(tf_wo_rec > 0)) {
         tfs <- tfs[-tf_wo_rec]
         }

--- a/R/utils.R
+++ b/R/utils.R
@@ -97,10 +97,10 @@ dom_tf_activation <- function(dom) {
 #' 
 dom_correlations <- function(dom, type = "rl") {
     if (type == "complex") {
-        corrs = slot(dom, "cor")
+        corrs <- slot(dom, "cor")
     } else if (type == "rl") {
-        misc = slot(dom, "misc")
-        corrs = misc$rec_cor
+        misc <- slot(dom, "misc")
+        corrs <- misc$rec_cor
     } else {
         stop("Type must be either 'rl' or 'complex'")
     }

--- a/man/check_arg.Rd
+++ b/man/check_arg.Rd
@@ -35,6 +35,9 @@ check_arg(
 
 \item{need_names}{Logical for whether names are required}
 }
+\value{
+logical
+}
 \description{
 Accepts an object and rules for checking, stops if rules not met.
 }

--- a/man/circos_ligand_receptor.Rd
+++ b/man/circos_ligand_receptor.Rd
@@ -35,7 +35,7 @@ receptor where chord widths correspond to mean ligand expression by the cluster.
 circos_ligand_receptor(dominoSignal:::pbmc_dom_built_tiny, receptor = "CXCR3")
 #specify colors
 cols = c("red", "orange", "green", "blue", "pink", "purple", "slategrey", "firebrick", "hotpink")
-names(cols) = levels(dominoSignal:::pbmc_dom_built_tiny@clusters)
+names(cols) = levels(dom_clusters(dominoSignal:::pbmc_dom_built_tiny))
 circos_ligand_receptor(dominoSignal:::pbmc_dom_built_tiny, receptor = "CXCR3", cell_colors = cols)
 
 }

--- a/man/domino-class.Rd
+++ b/man/domino-class.Rd
@@ -5,6 +5,9 @@
 \alias{domino-class}
 \alias{domino}
 \title{The domino Class}
+\value{
+an instance of class \code{domino }
+}
 \description{
 The domino class contains all information necessary to calculate receptor-ligand
 signaling. It contains z-scored expression, cell cluster labels, feature values,

--- a/man/linkage_summary-class.Rd
+++ b/man/linkage_summary-class.Rd
@@ -5,6 +5,9 @@
 \alias{linkage_summary-class}
 \alias{linkage_summary}
 \title{The domino linkage summary class}
+\value{
+an instance of class \code{linkage_summary}
+}
 \description{
 The linkage summary class contains linkages established in multiple domino
 objects through gene regulatory network inference and reference to receptor-

--- a/tests/testthat/test-processing_fxns.R
+++ b/tests/testthat/test-processing_fxns.R
@@ -1,0 +1,14 @@
+## unit tests use internal data stored in R/sysdata.R
+
+test_that("build_domino runs correctly", {
+  # use rl_map created in domino2 v0.2.1
+  dom_build <- build_domino(
+    pbmc_dom_tiny,
+    min_tf_pval = .05,
+    max_tf_per_clust = Inf,
+    max_rec_per_tf = Inf,
+    rec_tf_cor_threshold = .1,
+    min_rec_percentage = 0.01
+  )
+  expect_equal(dom_build, pbmc_dom_built_tiny)
+})


### PR DESCRIPTION
Addresses notes associated with coding practices called by BiocCheck including:
- replacing use of sapply with vapply or lapply
- replace use of 1:n with seq or seq_along
- replace use of = for assignment with <-
- remove redundant use of paste functions in condition signals (message, warning, error)

Other fixes include replacing uses of @ in function examples with accessor function calls and specifying the logical return value of check_args