### PR TITLE
Remove domino2 occurance

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dominoSignal
 Title: Cell Communication Analysis for Single Cell RNA Sequencing
-Version: 0.99.3
+Version: 0.99.4
 Authors@R: c(
     person("Christopher", "Cherry", role = c("aut"), email = "ccherry.6574@gmail.com", comment = c(ORCID = "0000-0002-5481-0055")),
     person("Jacob T", "Mitchell", role = c("aut", "cre"), email = "jmitch81@jhmi.edu", comment = c(ORCID = "0000-0002-5370-9692")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,9 @@
+# dominoSignal v0.99.4
+
+## Vignettes
+
+- Updated download instructions to use the bioconductor URL
+
 # dominoSignal v0.99.3
 
 ## create_domino Function Warnings

--- a/tests/testthat/test-regression.R
+++ b/tests/testthat/test-regression.R
@@ -3,7 +3,7 @@
 
 ## large scale test that processing functions generate results matching the state of the code in v0.2.1
 test_that("creation of rl_map from CellPhoneDB v4 input", {
-  # use rl_map created in domino2 v0.2.1
+  # use rl_map created in dominoSignal v0.2.1
   rl_map <- create_rl_map_cellphonedb(
     genes = v0.2.1$genes_tiny,
     proteins = v0.2.1$proteins_tiny,
@@ -14,14 +14,14 @@ test_that("creation of rl_map from CellPhoneDB v4 input", {
 })
 
 test_that("formating of SCENIC regulons output as a list", {
-  # use regulon list created in domino2 v0.2.1
+  # use regulon list created in dominoSignal v0.2.1
   regulon_ls <- create_regulon_list_scenic(regulons = v0.2.1$regulons_tiny)
   expect_equal(regulon_ls, v0.2.1$regulon_list_tiny)
 })
 
 test_that("creation of a domino object from SCENIC and CellPhoneDB inputs", {
-  # domino object created in domino2 v0.2.1
-  # rl_map created in domino2 v0.2.1 from CellPhoneDB v4
+  # domino object created in dominoSignal v0.2.1
+  # rl_map created in dominoSignal v0.2.1 from CellPhoneDB v4
   # scenic inputs from pySCENIC v0.11.0
   # minimal expression data from 360 cells in 3 cell types,
   # expression features for 16 genes
@@ -45,8 +45,8 @@ test_that("creation of a domino object from SCENIC and CellPhoneDB inputs", {
 })
 
 test_that("building a domino object under set parameters", {
-  # built domino object created in domino2 v0.2.1
-  # domino object created in domino2 v0.2.1
+  # built domino object created in dominoSignal v0.2.1
+  # domino object created in dominoSignal v0.2.1
   pbmc_dom_built <- build_domino(
     dom = v0.2.1$pbmc_dom_tiny,
     min_tf_pval = .05,

--- a/vignettes/dominoSignal.Rmd
+++ b/vignettes/dominoSignal.Rmd
@@ -83,13 +83,14 @@ pbmc <- readRDS(pbmc)
 
 ## Installation
 
-Installation of dominoSignal from Github can be achieved using the `{remotes}` package.
+Installation of dominoSignal from Bioconductor can be achieved using the `{BiocManager}` package.
 
-```{r, eval = FALSE}
-if(!require(remotes)){
-    install.packages("remotes")
+```{r, eval=FALSE}
+if (!require("BiocManager", quietly = TRUE)){
+  install.packages("BiocManager")
 }
-remotes::install_github("FertigLab/dominoSignal")
+
+BiocManager::install("DominoSignal")
 ```
 
 ## Loading TF and R - L data


### PR DESCRIPTION
- increment version to 0.99.4
- remove comments including the "domino2" package name, retaining the mention in NEWS.md signifying the version when the package name was changed
- vignette inclusion of download instruction directs users to use biocManager to install the package