### PR TITLE
Check for list of only NULLs in signaling from complexes

### DIFF
--- a/R/processing_fxns.R
+++ b/R/processing_fxns.R
@@ -136,11 +136,12 @@ build_domino <- function(
         inc_ligs <- unlist(inc_ligs_list)
       }
       lig_genes <- intersect(inc_ligs, rownames(dom@z_scores))
-      if (length(lig_genes) %in% c(0, 1)) {
+      if (length(lig_genes) == 0) {
         lig_genes <- numeric(0)
       }
       cl_sig_mat <- matrix(0, ncol = length(levels(dom@clusters)), nrow = length(lig_genes))
       colnames(cl_sig_mat) <- colnames(signaling)
+      if (!identical(lig_genes, numeric(0))) {rownames(cl_sig_mat) <- lig_genes}
       rownames(cl_sig_mat) <- lig_genes
       for (c2 in levels(dom@clusters)) {
         n_cell <- length(which(dom@clusters == c2))
@@ -170,7 +171,7 @@ build_domino <- function(
           }
         })
         names(cl_sig_list) <- names(inc_ligs_list)
-        if (length(cl_sig_list) > 1) {
+        if (length(cl_sig_list) > 1 & !all(sapply(cl_sig_list, is.null))) {
           cl_sig_mat <- do.call(rbind, cl_sig_list)
         }
       }


### PR DESCRIPTION
When list of complexes only contains NULL values, it will not be added to the existing signaling information.

Should resolve #53 