### PR TITLE
Files required for pkgdown customization

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -1,0 +1,151 @@
+url: https://FertigLab.github.io/dominoSignal
+
+deploy:
+  install_metadata: true
+
+template:
+  bootstrap: 5
+  theme: a11y-light
+  bootswatch: zephyr
+  bslib:
+    primary: "#7DDED2"
+    secondary: "#1D132B"
+    pkgdown-nav-height: 100px
+    nav-link-color: "#1D132B"
+    nav-tabs-link-active-bg: "#DFD4EC"
+    headings-color: "#457E78"
+    component-active-bg: "#DFD4EC"
+    code-font-size: 95%
+    code-bg: "#FEFEFE"
+    link-color: "#8963BA"
+    border-color: "#F4F0FA"
+    code_font: { google: "Fira Code" }
+    border-width: 2px
+
+
+reference:
+- title: "Domino Classes"
+  desc: >
+    An object class designed to store information used 
+    and produced in dominoSignal analysis
+  contents:
+  - domino-class
+  - linkage_summary
+- title: "Analysis Functions"
+  desc: >
+    Functions for performing cell-cell communication analysis
+    with the dominoSignal package
+  contents:
+  - create_rl_map_cellphonedb
+  - create_regulon_list_scenic
+  - create_domino
+  - build_domino
+  - summarize_linkages
+  - test_differential_linkages
+- title: "Plotting Functions"
+  desc: "Functions for visualizing dominoSignal analysis results"
+- subtitle: "Heatmaps"
+  contents:
+  - cor_heatmap
+  - feat_heatmap
+  - incoming_signaling_heatmap
+  - signaling_heatmap
+- subtitle: "Network Plots"
+  contents:
+  - gene_network
+  - signaling_network
+- subtitle: "Other Plots"
+  contents:
+  - circos_ligand_receptor
+  - cor_scatter
+  - plot_differential_linkages
+- title: "Helper Functions"
+  desc: "Convenience functions for working with dominoSignal objects"
+- subtitle: "Access functions"
+  contents:
+  - dom_clusters
+  - dom_correlations
+  - dom_counts
+  - dom_database
+  - dom_de
+  - dom_info
+  - dom_linkages
+  - dom_network_items
+  - dom_signaling
+  - dom_tf_activation
+  - dom_zscores
+- subtitle: "Misc. utility functions"
+  contents:
+  - add_rl_column
+  - count_linkage
+  - mean_ligand_expression
+  - print,domino-method
+  - rename_clusters
+  - show,domino-method
+- title: "Example Data"
+  desc: >
+    Example data used for testing and demonstration purposes
+  contents:
+  - CellPhoneDB
+  - SCENIC
+  - PBMC
+  - mock_linkage_summary
+
+navbar:
+  type: light
+  structure:
+    left:  [intro, articles, reference, news]
+    right: [search, github]
+    components:
+      articles:
+        text: Tutorials
+        menu:
+        - text: SCENIC for TF Scoring
+          href: vignettes/articles/tf_scenic_vignette.html
+        - text: Using CellphoneDB
+          href: vignettes/articles/cellphonedb_vignette.html
+        - text: Domino Object Structure
+          href: vignettes/domino_object_vignette.html
+        - text: Plotting and Visualization
+          href: vignettes/plotting_vignette.html
+
+home:
+  title: Cell Communication from Single Cell RNA Sequencing Data
+  description: >
+    dominoSignal uses transcription factor activation and ligand - receptor linkages to infer intra- and inter- cellular signaling from single cell RNA sequencing data.
+  sidebar:
+    structure: [toc, authors, labs, citation, license]
+    components:
+      labs:
+        title: Contributing Labs
+        text: |
+              For more information about these labs, click below.\n
+
+              <a href=https://elisseefflab.jhu.edu/> Elisseeff Lab </a> \n
+
+              <a href=https://fertiglab.com/> Fertig Lab </a>
+
+footer:
+  structure:
+    left: [package, developed_by]
+    right: built_with
+
+news:
+  one_page: true
+  cran_dates: false
+  releases:
+  - text: "dominoSignal v0.2.1"
+    href: https://github.com/FertigLab/dominoSignal/releases/tag/v0.2.1-alpha
+  - text: "dominoSignal v0.2.2"
+    href: https://github.com/FertigLab/dominoSignal/releases/tag/v0.2.2-alpha
+  - text: "dominoSignal v0.99.2"
+    href: https://github.com/FertigLab/dominoSignal/releases/tag/v0.99.2-alpha
+  - text: "dominoSignal v1.0.0 for Bioconductor"
+    href: https://github.com/FertigLab/dominoSignal/releases/tag/v1.0.0-Bioconductor
+
+authors:
+  footer:
+    roles: aut
+    text: "is developed by"
+  sidebar:
+    roles: [aut, ctb]

--- a/index.Rmd
+++ b/index.Rmd
@@ -1,0 +1,50 @@
+---
+output: github_document
+---
+
+<!-- index.md is generated from index.Rmd. Please edit that file -->
+
+```{r, include = FALSE}
+knitr::opts_chunk$set(
+    collapse = TRUE,
+    comment = "#>",
+    fig.path = "man/figures/README-",
+    out.width = "100%"
+)
+```
+
+## Introducing dominoSignal <a href="https://fertiglab.github.io/dominoSignal/"><img src="man/figures/logo.svg" align="right" height="138" style="float:right; height:138px;" alt="dominoSignal logo" /></a>
+
+dominoSignal is an updated version of the original [domino](https://github.com/Elisseeff-Lab/domino) R package published in Nature Biomedical Engineering in [Computational reconstruction of the signalling networks surrounding implanted biomaterials from single-cell transcriptomics](https://doi.org/10.1038/s41551-021-00770-5). dominoSignal is a tool for analysis of intra- and intercellular signaling in single cell RNA sequencing data based on transcription factor activation and receptor and ligand linkages.
+
+## Installation
+
+dominoSignal is undergoing active development to improve analysis capabilities and interpretability, so the codebase is subject to change as new features and fixes are implemented. The current version of dominoSignal can be found on [Bioconductor](https://bioconductor.org/packages/release/bioc/html/dominoSignal.html) though the package is still undergoing development (see our [changelog](news/index.html) for more information on changes). This version can be installed through Bioconductor.
+
+```{r, eval = FALSE}
+if (!requireNamespace("BiocManager")) {
+    install.packages("BiocManager")
+}
+BiocManager::install("dominoSignal")
+```
+
+The development version is currently hosted on the [FertigLab GitHub](https://github.com/FertigLab) on the [dominoSignal GitHub repository](https://github.com/FertigLab/dominoSignal), and can be installed using the remotes package.
+
+```{r, eval = FALSE}
+if (!require(remotes)) {
+    install.packages("remotes")
+}
+remotes::install_github("FertigLab/dominoSignal")
+```
+
+## Usage Overview
+
+Here is an overview of how dominoSignal might be used in analysis of a single cell RNA sequencing data set:
+
+1. Transcription factor activation scores are calculated (we recommend using [pySCENIC](https://pyscenic.readthedocs.io/en/latest/), but other methods can be used as well). For more information on how to use SCENIC, please see our [Using SCENIC for TF Activation](vignette("articles/scenic_vignette")) page.
+2. A ligand-receptor database is used to map linkages between ligands and receptors (we recommend using [cellphoneDB](https://www.cellphonedb.org/), but other methods can be used as well). For information on downloading the necessary files for cellphoneDB, please see our [Using the cellphoneDB Database](vignette("articles/cellphonedb_vignette")) page.
+3. A domino object is created using counts, z-scored counts, clustering information, and the data from steps 1 and 2.
+4. Parameters such as the maximum number of transcription factors and receptors or the minimum correlation threshold (among others) are used to make a cell communication network
+5. Communication networks can be extracted from within the domino object or visualized using a variety of plotting functions
+
+Please see the [Getting Started](vignette("dominoSignal")) page for an example analysis that includes all of these steps in a dominoSignal analysis in detail, from creating a domino object to parameters for building the network to visualizing domino results. Other articles include further details on [plotting functions](vignette("plotting_vignette")) and the structure of the [domino object](vignette("domino_object_vignette")).

--- a/index.md
+++ b/index.md
@@ -1,0 +1,45 @@
+---
+output: github_document
+---
+
+<!-- index.md is generated from index.Rmd. Please edit that file -->
+
+
+
+## Introducing dominoSignal <a href="https://fertiglab.github.io/dominoSignal/"><img src="man/figures/logo.svg" align="right" height="138" style="float:right; height:138px;" alt="dominoSignal logo" /></a>
+
+dominoSignal is an updated version of the original [domino](https://github.com/Elisseeff-Lab/domino) R package published in Nature Biomedical Engineering in [Computational reconstruction of the signalling networks surrounding implanted biomaterials from single-cell transcriptomics](https://doi.org/10.1038/s41551-021-00770-5). dominoSignal is a tool for analysis of intra- and intercellular signaling in single cell RNA sequencing data based on transcription factor activation and receptor and ligand linkages.
+
+## Installation
+
+dominoSignal is undergoing active development to improve analysis capabilities and interpretability, so the codebase is subject to change as new features and fixes are implemented. The current version of dominoSignal can be found on [Bioconductor](https://bioconductor.org/packages/release/bioc/html/dominoSignal.html) though the package is still undergoing development (see our [changelog](news/index.html) for more information on changes). This version can be installed through Bioconductor.
+
+
+```r
+if (!requireNamespace("BiocManager")) {
+    install.packages("BiocManager")
+}
+BiocManager::install("dominoSignal")
+```
+
+The development version is currently hosted on the [FertigLab GitHub](https://github.com/FertigLab) on the [dominoSignal GitHub repository](https://github.com/FertigLab/dominoSignal), and can be installed using the remotes package.
+
+
+```r
+if (!require(remotes)) {
+    install.packages("remotes")
+}
+remotes::install_github("FertigLab/dominoSignal")
+```
+
+## Usage Overview
+
+Here is an overview of how dominoSignal might be used in analysis of a single cell RNA sequencing data set:
+
+1. Transcription factor activation scores are calculated (we recommend using [pySCENIC](https://pyscenic.readthedocs.io/en/latest/), but other methods can be used as well). For more information on how to use SCENIC, please see our [Using SCENIC for TF Activation](vignette("articles/scenic_vignette")) page.
+2. A ligand-receptor database is used to map linkages between ligands and receptors (we recommend using [cellphoneDB](https://www.cellphonedb.org/), but other methods can be used as well). For information on downloading the necessary files for cellphoneDB, please see our [Using the cellphoneDB Database](vignette("articles/cellphonedb_vignette")) page.
+3. A domino object is created using counts, z-scored counts, clustering information, and the data from steps 1 and 2.
+4. Parameters such as the maximum number of transcription factors and receptors or the minimum correlation threshold (among others) are used to make a cell communication network
+5. Communication networks can be extracted from within the domino object or visualized using a variety of plotting functions
+
+Please see the [Getting Started](vignette("dominoSignal")) page for an example analysis that includes all of these steps in a dominoSignal analysis in detail, from creating a domino object to parameters for building the network to visualizing domino results. Other articles include further details on [plotting functions](vignette("plotting_vignette")) and the structure of the [domino object](vignette("domino_object_vignette")).


### PR DESCRIPTION
_pkgdown.yml file added as required for custom configuration of documentation site.
index.Rmd (and knitted output index.Rd) added as required to ensure home page of documentation site and github readme file are different (so documentation site doesn't include link to itself, for example).

Addition of files to master branch should allow github action for pkgdown to compile website with this customization.