### PR TITLE
update to version 1.0.5

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -1,6 +1,6 @@
 Package: dominoSignal
 Title: Cell Communication Analysis for Single Cell RNA Sequencing
-Version: 1.0.4
+Version: 1.0.5
 Authors@R: c(
     person("Christopher", "Cherry", role = c("aut"), email = "ccherry.6574@gmail.com", comment = c(ORCID = "0000-0002-5481-0055")),
     person("Jacob T", "Mitchell", role = c("aut", "cre"), email = "jmitch81@jhmi.edu", comment = c(ORCID = "0000-0002-5370-9692")),

--- a/NEWS.md
+++ b/NEWS.md
@@ -1,3 +1,7 @@
+# dominoSignal v1.0.5
+
+- circos_ligand_receptor will not fail in cases where the rl_map of a domino objects includes ligands for a receptor where the ligands are not present in the expression matrix. A message is returned if ligands from the rl_map had to be excluded from the plot
+
 # dominoSignal v1.0.4
 
 - refactorization of circos_ligand_receptor function to remove use of grepl-based regular expressions to reformat cell and molecule names from a domino object into a data frame for plotting a receptor circos plot. Component functions for creating the data frame of ligand expression centered on a single receptor and to render this data frame as a circos plot are now included in the package as "obtain_circos_expression" and "render_circos_ligand_receptor", respectively.

--- a/R/plot_fxns.R
+++ b/R/plot_fxns.R
@@ -822,6 +822,22 @@ obtain_circos_expression <- function(dom, receptor, ligands, ligand_expression_t
     sig <- dom@cl_signaling_matrices[active_cell][[1]]
     cell_names <- gsub("^L_", "", colnames(sig))
     
+    
+    # ensure only ligands present in the signaling matrix are considered
+    lig_check <- ligands %in% rownames(sig)
+    if(length(lig_check) != sum(lig_check)){
+      message(paste0(
+        "Ligands: ", paste(ligands[!lig_check], collapse = ","),
+        " of receptor ", receptor, " are listed in the rl_map, but not present in the signaling matrix."
+      ))
+      if(sum(lig_check) == 0){
+        stop(paste0("No ligands of receptor ", receptor, " present in signaling matrix."))
+      } else {
+        message(paste0("Only ligands: ", paste(ligands[lig_check], collapse = ","), " will be considered."))
+      }
+    }
+    ligands <- ligands[lig_check]
+    
     lig_signal_ls <- lapply(
       setNames(ligands, nm = ligands), 
       function(l){


### PR DESCRIPTION
- circos_ligand_receptor will not fail in cases where the rl_map of a domino objects includes ligands for a receptor where the ligands are not present in the expression matrix. A message is returned if ligands from the rl_map had to be excluded from the plot